### PR TITLE
chore: Use `registry: cloudquery` in configuration spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ kind: source
 spec:
   name: "googleworkspace"
   path: "jsifuentes/googleworkspace"
-  registry: "github"
+  registry: "cloudquery"
   version: "v1.0.1"
   destinations:
     - "postgresql"

--- a/docs/_configuration.md
+++ b/docs/_configuration.md
@@ -11,7 +11,7 @@ kind: source
 spec:
   name: "googleworkspace"
   path: "jsifuentes/googleworkspace"
-  registry: "github"
+  registry: "cloudquery"
   version: "v1.0.1"
   destinations:
     - "postgresql"


### PR DESCRIPTION
Thanks for this plugin 🚀 

This PR updates the registry field to point to `cloudquery` registry (our Hub). This is the default for CLI versions >=4, so we could also remove it altogether.

This change will be reflected [in the Hub](https://hub.cloudquery.io/plugins/source/jsifuentes/googleworkspace) for future versions released with this PR.
For existing versions you can update the docs directly via https://cloud.cloudquery.io/teams/jsifuentes/packages/plugins/source/googleworkspace/versions/v1.0.1 