### PR TITLE
feat: add projection full for users table

### DIFF
--- a/resources/services/users/users.go
+++ b/resources/services/users/users.go
@@ -41,7 +41,7 @@ func UsersTable() *schema.Table {
 
 func fetchUsers(ctx context.Context, meta schema.ClientMeta, _ *schema.Resource, res chan<- any) error {
 	c := meta.(*client.Client)
-	return c.DirectoryService.Users.List().Customer(c.Spec.CustomerID).Pages(ctx, func(users *directory.Users) error {
+	return c.DirectoryService.Users.List().Customer(c.Spec.CustomerID).Projection("full").Pages(ctx, func(users *directory.Users) error {
 		for _, u := range users.Users {
 			res <- u
 		}


### PR DESCRIPTION
By setting the projection to "full," you're essentially specifying that you want to retrieve all available information related to the user, including `customSchema`, which refers to any custom attributes or fields that have been defined within the Google Workspace user profiles. 

This change will ensure that you can access and utilize a more extensive range of user data, providing a more detailed and comprehensive view of user information within the Google Workspace.

```
// Possible values:
//
//	"basic" (default) - Do not include any custom fields for the user.
//	"custom" - Include custom fields from schemas requested in
//
// `customFieldMask`.
//
//	"full" - Include all fields associated with this user.
```